### PR TITLE
fix(xy): the style is invalid when area and line charts are combined

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -263,7 +263,6 @@
                   "gridDisplay":true,
                   "title":"category",
                   "enableColor":true,
-                  "position":"left"
                 },
                 "valueAxis":{
                   "title":"value"
@@ -278,7 +277,7 @@
           </div>
           <div>
             <mdw-xy
-              type="bar"
+              type="column"
               style="width: 40%"
               data='[["Year", "Things", "Stuff"],
               ["2004", 1000, 400],

--- a/src/components/xy-chart/xy-chart.options.ts
+++ b/src/components/xy-chart/xy-chart.options.ts
@@ -5,7 +5,6 @@ const defaultXYChartOptions: XYChartOptions = {
     gridDisplay: true,
     display: true,
     stacked: false,
-    dataKey: '',
   },
   valueAxis: {
     gridDisplay: true,

--- a/src/components/xy-chart/xy-chart.types.ts
+++ b/src/components/xy-chart/xy-chart.types.ts
@@ -3,20 +3,61 @@
  */
 import { TimeUnit } from 'chart.js';
 import { ChartOptions } from '../../types';
+
+/**
+ * Interface `AxisOptions` provides a set of configurations for the axis in a chart.
+ */
 interface AxisOptions {
+  /**
+   * Title of the axis.
+   */
   title?: string;
+  /**
+   * Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart.
+   */
   type?: 'category' | 'time';
+  /**
+   * The location of the axis on the chart.
+   */
   position?: 'left' | 'right' | 'top' | 'bottom' | 'center';
+  /**
+   * Should the data be stacked.
+   */
   stacked?: boolean;
+  /**
+   * Controls the axis global visibility (visible when true, hidden when false)
+   */
   display?: boolean;
+  /**
+   * Controls the grid of axis global visibility (visible when true, hidden when false)
+   */
   gridDisplay?: boolean;
 }
 
+/**
+ * This interface provides options for configuring the category axis.
+ */
 interface CategoryAxisOptions extends AxisOptions {
+  /**
+   * Set to true, the colors of each category of the series are recycled.
+   * Set to false, all categories of each series are one color
+   */
   enableColor?: boolean;
-  dataKey: string;
+  /**
+   *  The category field on the category axis.
+   */
+  dataKey?: string;
+  /**
+   * Specifies the time unit on the category axis.
+   */
   timeUnit?: TimeUnit;
+  /**
+   * Specifies the date format of labels on the category axis.
+   */
   labelFormat?: string;
+  /**
+   * Specifies the format of the tooltip displayed for data points on the category axis.
+   */
   tooltipFormat?: string;
 }
 interface ValueAxisOptions extends AxisOptions {
@@ -24,19 +65,38 @@ interface ValueAxisOptions extends AxisOptions {
 }
 
 export interface XYChartOptions extends ChartOptions {
+  /**
+   * The options for the series.
+   */
   seriesOptions?: {
+    /**
+     * The style mapping is an object where keys are string identifiers.
+     */
     styleMapping: {
       [key: string]: {
-        type?: 'bar' | 'line';
+        type?: 'bar' | 'line' | 'area';
         lineStyle?: 'solid' | 'dashed';
       };
     };
   };
+  /**
+   * Options for configuring the category axis.
+   */
   categoryAxis?: CategoryAxisOptions;
+  /**
+   * Options for configuring the value axis.
+   */
   valueAxis?: ValueAxisOptions;
 }
-// export type DataTableLike = unknown[][] | { cols: unknown[]; rows?: unknown[][] };
+
+/**
+ * The "DataTableLike" type can be a two-dimensional array (unknown[][]) or an array of objects (Record<string, string | number>[]).
+ */
 export type DataTableLike = unknown[][] | Record<string, string | number>[];
+
+/**
+ * Data model required for chart rendering.
+ */
 export type DataView = {
   category: { name?: string; labels?: unknown[] };
   series: {
@@ -45,8 +105,14 @@ export type DataView = {
   }[];
 };
 
+/**
+ * Common data model
+ */
 export interface GenericDataModel {
-  categoryKey?: string;
+  /**
+   *  The category field on the category axis.
+   */
+  dataKey?: string;
   data: {
     [key: string]: string | number;
   }[];

--- a/website/docs/tutorials/area.mdx
+++ b/website/docs/tutorials/area.mdx
@@ -1,4 +1,10 @@
+---
+sidebar_position: 108
+---
+
 # Area Chart
+
+Area chart support a fill area on the dataset object which can be used to create space between a dataset and a boundary.
 
 ```jsx live
 function showComponent() {

--- a/website/docs/tutorials/area.mdx
+++ b/website/docs/tutorials/area.mdx
@@ -1,0 +1,28 @@
+# Area Chart
+
+```jsx live
+function showComponent() {
+  const data = [
+    ['Year', 'Things', 'Stuff'],
+    ['2004', 1000, 400],
+    ['2005', 1170, 460],
+    ['2006', 660, 1120],
+    ['2007', 1030, 540],
+  ];
+  const options = {
+    title: 'My First Area Chart',
+    theme: 'material',
+    seriesOptions: {
+      styleMapping: {
+        Stuff: {
+          type: 'line',
+        },
+      },
+    },
+    legend: {
+      isLegendClick: true,
+    },
+  };
+  return <mdw-xy type="area" data={JSON.stringify(data)} options={JSON.stringify(options)}></mdw-xy>;
+}
+```

--- a/website/docs/tutorials/bar.mdx
+++ b/website/docs/tutorials/bar.mdx
@@ -1,6 +1,10 @@
+---
+sidebar_position: 104
+---
+
 # Bar Chart
 
-A bar chart provides a way of showing data values represented as vertical bars. It is sometimes used to show trend data, and the comparison of multiple data sets side by side.
+Bar chart provides a way of showing data values represented as horizontal bars. It is sometimes used to show trend data, and the comparison of multiple data sets side by side.
 
 ```jsx live
 function showComponent() {
@@ -57,12 +61,12 @@ These are only the common options supported by all axes. Please see specific axi
 
 | Name        | Type                                               | Default | Description                                                                                                                                        |
 | ----------- | -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title       | string                                             |         | Title of value axis.                                                                                                                               |
-| type        | 'category' \| 'time'                               |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart. |
-| position    | 'left' \| 'right' \| 'top' \| 'bottom' \| 'center' |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.             |
-| display     | boolean                                            | true    | Controls the axis global visibility (visible when true, hidden when false).                                                                        |
-| gridDisplay | boolean                                            | true    | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                |
-| stacked     | boolean                                            | false   | Should the data be stacked.                                                                                                                        |
+| title       | `string`                                           |         | Title of value axis.                                                                                                                               |
+| type        | `category` \| `time`                               |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart. |
+| position    | `left` \| `right` \| `top` \| `bottom` \| `center` |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.             |
+| display     | `boolean`                                          | `true`  | Controls the axis global visibility (visible when true, hidden when false).                                                                        |
+| gridDisplay | `boolean`                                          | `true`  | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                |
+| stacked     | `boolean`                                          | `false` | Should the data be stacked.                                                                                                                        |
 
 ### SeriesOptions
 
@@ -76,21 +80,21 @@ The options for the series.
 
 | Name      | Type                      | Default | Description                                                                       |
 | --------- | ------------------------- | ------- | --------------------------------------------------------------------------------- |
-| key       | string                    |         | Series name.                                                                      |
-| type      | 'bar' \| 'line' \| 'area' |         | The chart type of the series, if not set, it will be the same as the global type. |
-| lineStyle | 'solid' \| 'dashed'       | 'solid' | The line style of the series                                                      |
+| key       | `string`                  |         | Series name.                                                                      |
+| type      | `bar` \| `line` \| `area` |         | The chart type of the series, if not set, it will be the same as the global type. |
+| lineStyle | `solid` \| `dashed`       | `solid` | The line style of the series                                                      |
 
 ### CategoryAxisOptions
 
 CategoryAxisOptions extends [AxisOptions](#axisoptions)
 
-| Name          | Type     | Default | Description                                                                                                                                                  |
-| ------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| enableColor   | boolean  | false   |                                                                                                                                                              |
-| dataKey       | string   |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
-| timeUnit      | TimeUnit |         | Specifies the time unit on the category axis.                                                                                                                |
-| labelFormat   | string   |         | Specifies the date format of labels on the category axis.                                                                                                    |
-| tooltipFormat | string   |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
+| Name          | Type       | Default | Description                                                                                                                                                  |
+| ------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| enableColor   | `boolean`  | `false` |                                                                                                                                                              |
+| dataKey       | `string`   |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
+| timeUnit      | `TimeUnit` |         | Specifies the time unit on the category axis.                                                                                                                |
+| labelFormat   | `string`   |         | Specifies the date format of labels on the category axis. See chartjs-adapter-moment                                                                         |
+| tooltipFormat | `string`   |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
 
 ### ValueAxisOptions
 

--- a/website/docs/tutorials/bar.mdx
+++ b/website/docs/tutorials/bar.mdx
@@ -1,0 +1,97 @@
+# Bar Chart
+
+A bar chart provides a way of showing data values represented as vertical bars. It is sometimes used to show trend data, and the comparison of multiple data sets side by side.
+
+```jsx live
+function showComponent() {
+  const data = [
+    ['Year', 'Things'],
+    ['2004', 1000],
+    ['2005', 1170],
+    ['2006', 660],
+    ['2007', 1030],
+  ];
+  const options = {
+    categoryAxis: {
+      gridDisplay: true,
+      title: 'category',
+      enableColor: true,
+    },
+    valueAxis: {
+      title: 'value',
+    },
+    title: 'My First Bar Chart',
+    theme: 'qualitative-colors-primary',
+    legend: {
+      isLegendClick: false,
+    },
+  };
+  return <mdw-xy type="bar" data={JSON.stringify(data)} options={JSON.stringify(options)}></mdw-xy>;
+}
+```
+
+## Type
+
+type = 'bar'
+
+## Data
+
+The data supports the following multiple data formats:
+
+| Mode                  | Type                               | Example                                                                                                                  |
+| --------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Two-dimensional array | unknown[][]                        | [['Year','Things'],['2004',1000],['2005',1170],['2006',660],['2007',1030]]                                               |
+| Array                 | Record<string, string \| number>[] | [{"Year":"2004","Things":1000},{"Year":"2005","Things":1170},{"Year":"2006","Things":660},{"Year":"2007","Things":1030}] |
+
+## Options
+
+| Name          | Type                                        | Description                                           |
+| ------------- | ------------------------------------------- | ----------------------------------------------------- |
+| seriesOptions | [SeriesOptions](#seriesoptions)             | Series related configuration, including styleMapping. |
+| categoryAxis  | [CategoryAxisOptions](#categoryaxisoptions) | Used to create a category-based axis for the chart.   |
+| valueAxis     | [ValueAxisOptions](#valueaxisoptions)       | Used to create a value axis for the chart.            |
+
+### AxisOptions
+
+These are only the common options supported by all axes. Please see specific axis documentation for all the available options for that axis.
+
+| Name        | Type                                               | Default | Description                                                                                                                                        |
+| ----------- | -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title       | string                                             |         | Title of value axis.                                                                                                                               |
+| type        | 'category' \| 'time'                               |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart. |
+| position    | 'left' \| 'right' \| 'top' \| 'bottom' \| 'center' |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.             |
+| display     | boolean                                            | true    | Controls the axis global visibility (visible when true, hidden when false).                                                                        |
+| gridDisplay | boolean                                            | true    | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                |
+| stacked     | boolean                                            | false   | Should the data be stacked.                                                                                                                        |
+
+### SeriesOptions
+
+The options for the series.
+
+| Name         | Type                          | Default | Description                                                       |
+| ------------ | ----------------------------- | ------- | ----------------------------------------------------------------- |
+| styleMapping | [styleMapping](#stylemapping) |         | The style mapping is an object where keys are string identifiers. |
+
+#### styleMapping
+
+| Name      | Type                      | Default | Description                                                                       |
+| --------- | ------------------------- | ------- | --------------------------------------------------------------------------------- |
+| key       | string                    |         | Series name.                                                                      |
+| type      | 'bar' \| 'line' \| 'area' |         | The chart type of the series, if not set, it will be the same as the global type. |
+| lineStyle | 'solid' \| 'dashed'       | 'solid' | The line style of the series                                                      |
+
+### CategoryAxisOptions
+
+CategoryAxisOptions extends [AxisOptions](#axisoptions)
+
+| Name          | Type     | Default | Description                                                                                                                                                  |
+| ------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| enableColor   | boolean  | false   |                                                                                                                                                              |
+| dataKey       | string   |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
+| timeUnit      | TimeUnit |         | Specifies the time unit on the category axis.                                                                                                                |
+| labelFormat   | string   |         | Specifies the date format of labels on the category axis.                                                                                                    |
+| tooltipFormat | string   |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
+
+### ValueAxisOptions
+
+ValueAxisOptions extends [AxisOptions](#axisoptions)

--- a/website/docs/tutorials/column.mdx
+++ b/website/docs/tutorials/column.mdx
@@ -1,0 +1,29 @@
+# Column Chart
+
+```jsx live
+function showComponent() {
+  const data = [
+    ['Year', 'Things', 'Stuff'],
+    ['2004', 1000, 400],
+    ['2005', 1170, 460],
+    ['2006', 660, 1120],
+    ['2007', 1030, 540],
+  ];
+  const options = {
+    categoryAxis: {
+      stacked: true,
+      enableColor: false,
+    },
+    valueAxis: {
+      stacked: true,
+      title: 'value',
+    },
+    title: 'My First Column Chart',
+    theme: 'qualitative-colors-primary',
+    legend: {
+      isLegendClick: true,
+    },
+  };
+  return <mdw-xy type="column" data={JSON.stringify(data)} options={JSON.stringify(options)}></mdw-xy>;
+}
+```

--- a/website/docs/tutorials/column.mdx
+++ b/website/docs/tutorials/column.mdx
@@ -1,4 +1,10 @@
+---
+sidebar_position: 105
+---
+
 # Column Chart
+
+Column chart provides a way of showing data values represented as vertical bars. It is sometimes used to show trend data, and the comparison of multiple data sets side by side.
 
 ```jsx live
 function showComponent() {
@@ -9,13 +15,13 @@ function showComponent() {
     ['2006', 660, 1120],
     ['2007', 1030, 540],
   ];
-  const options = {
+  const initialOptions = {
     categoryAxis: {
-      stacked: true,
+      stacked: false,
       enableColor: false,
     },
     valueAxis: {
-      stacked: true,
+      stacked: false,
       title: 'value',
     },
     title: 'My First Column Chart',
@@ -24,6 +30,45 @@ function showComponent() {
       isLegendClick: true,
     },
   };
-  return <mdw-xy type="column" data={JSON.stringify(data)} options={JSON.stringify(options)}></mdw-xy>;
+
+  const [options, setOptions] = useState(initialOptions);
+  const [key, setKey] = useState(new Date().getTime());
+  const handleButtonClick = (type) => {
+    setKey((preKey) => {
+      return new Date().getTime();
+    });
+    setOptions(() => {
+      const prevOptions = { ...initialOptions };
+      if (type === 'category') {
+        prevOptions.categoryAxis.stacked = !prevOptions.categoryAxis.stacked;
+      } else if (type === 'value') {
+        prevOptions.valueAxis.stacked = !prevOptions.valueAxis.stacked;
+      } else if (type === 'all') {
+        prevOptions.categoryAxis.stacked = !prevOptions.categoryAxis.stacked;
+        prevOptions.valueAxis.stacked = !prevOptions.valueAxis.stacked;
+      }
+      return {
+        ...prevOptions,
+      };
+    });
+  };
+  const actionStyle = { padding: '8px 16px', margin: '0 8px 8px 0', borderRadius: '6px', color: '#3080d0', cursor: 'pointer', background: 'rgba(48,128,208,.15)', borderColor: 'rgba(48,128,208,.2)' };
+  return (
+    <div>
+      <mdw-xy key={key} type="column" data={JSON.stringify(data)} options={JSON.stringify(options)}></mdw-xy>
+      <button style={actionStyle} onClick={handleButtonClick}>
+        Default
+      </button>
+      <button style={actionStyle} onClick={() => handleButtonClick('category')}>
+        Category Stacked
+      </button>
+      <button style={actionStyle} onClick={() => handleButtonClick('value')}>
+        Value Stacked
+      </button>
+      <button style={actionStyle} onClick={() => handleButtonClick('all')}>
+        All Stacked
+      </button>
+    </div>
+  );
 }
 ```

--- a/website/docs/tutorials/donut.mdx
+++ b/website/docs/tutorials/donut.mdx
@@ -1,6 +1,10 @@
+---
+sidebar_position: 111
+---
+
 import { useEffect, useRef } from 'react';
 
-# Doughnut Chart
+# Donut Chart
 
 Donut chart is a commonly used data visualization tool, often used to show the relative proportions between different categories or parts.
 
@@ -36,7 +40,7 @@ function showComponent() {
 | Name          | Type                                | Default | Description                                 |
 | ------------- | ----------------------------------- | ------- | ------------------------------------------- |
 | responsive    | `boolean`                           | `true`  | Resizes the chart canvas when its container |
-| chartLabel    | `string` or `number` or `string[]`; | -       | Data label                                  |
+| chartLabel    | `string` \| `number` \| `string[]`; | -       | Data label                                  |
 | theme         |                                     | -       | Chart theme                                 |
 | fontColor     | `string`                            | -       | Plugin text font color                      |
 | fontFamily    | `string`                            | -       | Plugin text font family                     |
@@ -59,13 +63,13 @@ function showComponent() {
 
 ** Legend related configuration **
 
-| Name               | Type                                | Default | Description                    |
-| ------------------ | ----------------------------------- | ------- | ------------------------------ |
-| legendDisplay      | `boolean`                           | true    | Legend show                    |
-| isLegendClick      | `boolean    `                       | 90%     | Change legend default behavior |
-| legendPosition     | `left` , `top` , `right` , `bottom` | `top`   | Legend position                |
-| legendLabelsWidth  | `number`                            | 12      | Legend color block width       |
-| legendLabelsHeight | `number`                            | 12      | Legend color block height      |
+| Name               | Type                                   | Default | Description                    |
+| ------------------ | -------------------------------------- | ------- | ------------------------------ |
+| legendDisplay      | `boolean`                              | true    | Legend show                    |
+| isLegendClick      | `boolean    `                          | 90%     | Change legend default behavior |
+| legendPosition     | `left` \| `top` \| `right` \| `bottom` | `top`   | Legend position                |
+| legendLabelsWidth  | `number`                               | 12      | Legend color block width       |
+| legendLabelsHeight | `number`                               | 12      | Legend color block height      |
 
 > If isLegendClick is set to true, the default click behavior of chart legend will be disabled.
 
@@ -111,13 +115,13 @@ function showComponent() {
 
 ** Tooltip related configuration **
 
-| Name                | Type              | Default | Description                 |
-| ------------------- | ----------------- | ------- | --------------------------- |
-| seriesTooltipHead   | `HTML`or `string` | -       | Series tooltip Header       |
-| seriesTooltipBody   | `HTML`or `string` | -       | Series tooltip Body         |
-| seriesTooltipFooter | `HTML`or `string` | -       | Series tooltip Footer       |
-| seriesTooltipFloor  | `number`          | 0       | Series tooltip number floor |
-| legendTooltipHead   | `HTML`or `string` | -       | Legend tooltip Header       |
-| legendTooltipBody   | `HTML`or `string` | -       | Legend tooltip Body         |
-| legendTooltipFooter | `HTML`or `string` | -       | Legend tooltip Footer       |
-| legendTooltipFloor  | `number`          | 0       | Legend tooltip number floor |
+| Name                | Type               | Default | Description                 |
+| ------------------- | ------------------ | ------- | --------------------------- |
+| seriesTooltipHead   | `HTML` \| `string` | -       | Series tooltip Header       |
+| seriesTooltipBody   | `HTML` \| `string` | -       | Series tooltip Body         |
+| seriesTooltipFooter | `HTML` \| `string` | -       | Series tooltip Footer       |
+| seriesTooltipFloor  | `number`           | 0       | Series tooltip number floor |
+| legendTooltipHead   | `HTML` \| `string` | -       | Legend tooltip Header       |
+| legendTooltipBody   | `HTML` \| `string` | -       | Legend tooltip Body         |
+| legendTooltipFooter | `HTML` \| `string` | -       | Legend tooltip Footer       |
+| legendTooltipFloor  | `number`           | 0       | Legend tooltip number floor |

--- a/website/docs/tutorials/gauge.mdx
+++ b/website/docs/tutorials/gauge.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 112
+---
+
 # Gauge Chart
 
 Gauge chart is a data visualization chart, usually used to show the relative position of a single indicator or value within a fixed range.
@@ -5,7 +9,6 @@ Gauge chart is a data visualization chart, usually used to show the relative pos
 It looks similar to a car dashboard and helps people quickly understand where a value falls within a predetermined range.
 
 Gauge charts usually consist of a circular ruler (gauge) and an indicator (needle).
-
 
 ```jsx live
 function showComponent() {

--- a/website/docs/tutorials/line.mdx
+++ b/website/docs/tutorials/line.mdx
@@ -1,0 +1,41 @@
+# Line Chart
+
+```jsx live
+function showComponent() {
+  const data = [
+    { dateTime: '2013-11-20T03:18:55.732Z', Arizona: 5523, Louisiana: 5239, Illinois: 5539, Tennessee: 816, 'Rhode Island': 270 },
+    { dateTime: '2013-12-20T03:18:55.732Z', Arizona: 315, Louisiana: 3868, Illinois: 182, Tennessee: 1926, 'Rhode Island': 6734 },
+    { dateTime: '2014-01-20T03:18:55.732Z', Arizona: 4244, Louisiana: 2462, Illinois: 9486, Tennessee: 7565, 'Rhode Island': 4514 },
+    { dateTime: '2014-02-20T03:18:55.732Z', Arizona: 2234, Louisiana: 3857, Illinois: 888, Tennessee: 1364, 'Rhode Island': 1752 },
+    { dateTime: '2014-03-20T03:18:55.732Z', Arizona: 6484, Louisiana: 2907, Illinois: 8919, Tennessee: 1369, 'Rhode Island': 9925 },
+  ];
+  const options = {
+    categoryAxis: {
+      gridDisplay: true,
+      title: 'category',
+      dataKey: 'dateTime',
+      type: 'time',
+      timeUnit: 'month',
+      labelFormat: 'MM DD, YYYY',
+    },
+    valueAxis: {
+      gridDisplay: false,
+      position: 'left',
+      title: 'value',
+    },
+    seriesOptions: {
+      styleMapping: {
+        Louisiana: {
+          lineStyle: 'dashed',
+        },
+      },
+    },
+    title: 'My First Line Chart',
+    theme: 'diverging-colors-alerts',
+    legend: {
+      isLegendClick: false,
+    },
+  };
+  return <mdw-xy type="line" data={JSON.stringify(data)} options={JSON.stringify(options)}></mdw-xy>;
+}
+```

--- a/website/docs/tutorials/line.mdx
+++ b/website/docs/tutorials/line.mdx
@@ -1,4 +1,10 @@
+---
+sidebar_position: 106
+---
+
 # Line Chart
+
+Line chart is a way of plotting data points on a line. Often, it is used to show trend data, or the comparison of two data sets.
 
 ```jsx live
 function showComponent() {

--- a/website/docs/tutorials/pie.mdx
+++ b/website/docs/tutorials/pie.mdx
@@ -1,6 +1,10 @@
+---
+sidebar_position: 110
+---
+
 # Pie Chart
 
-Pie and doughnut charts are probably the most commonly used charts. They are divided into segments, the arc of each segment shows the proportional value of each piece of data.
+Pie chart is probably the most commonly used charts. They are divided into segments, the arc of each segment shows the proportional value of each piece of data.
 
 They are excellent at showing the relational proportions between data.
 
@@ -8,22 +12,22 @@ They are excellent at showing the relational proportions between data.
 function showComponent() {
   const data = [
     {
-      A:'13',
-      B:'17',
-      C:'8',
-      D:'10',
-      E:'40',
-      F:'51',
-      G:'31'
-    }
+      A: '13',
+      B: '17',
+      C: '8',
+      D: '10',
+      E: '40',
+      F: '51',
+      G: '31',
+    },
   ];
   const options = {
-    chartLabel:'Label D',
+    chartLabel: 'Label D',
     theme: 'diverging-colors-alerts',
-    legend:{
-      'isLegendClick': true
-    }
-  }
+    legend: {
+      isLegendClick: true,
+    },
+  };
 
   return <mdw-pie style={{ width: '80%' }} data={JSON.stringify(data)} options={JSON.stringify(options)}></mdw-pie>;
 }

--- a/website/docs/tutorials/range.mdx
+++ b/website/docs/tutorials/range.mdx
@@ -1,4 +1,10 @@
+---
+sidebar_position: 109
+---
+
 # Range Chart
+
+Range chart support a fill area on the dataset object which can be used to create space between two datasets.
 
 ```jsx live
 function showComponent() {

--- a/website/docs/tutorials/range.mdx
+++ b/website/docs/tutorials/range.mdx
@@ -1,0 +1,18 @@
+# Range Chart
+
+```jsx live
+function showComponent() {
+  const data = [
+    ['Year', 'Things', 'Stuff'],
+    ['2004', 1000, 400],
+    ['2005', 1170, 460],
+    ['2006', 660, 1120],
+    ['2007', 1030, 540],
+  ];
+  const options = {
+    title: 'My First Range Area Chart',
+    theme: 'color-health',
+  };
+  return <mdw-xy type="range" data={JSON.stringify(data)} options={JSON.stringify(options)}></mdw-xy>;
+}
+```


### PR DESCRIPTION
## Description

>Fixed the problem that the style is invalid when area and line charts are combined.
>Add examples related to the XY chart 


## Screenshots

- [x] This PR does not have any UI modifications <!-- remove this line and attach the screenshots if you have any UI changes --> 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and example
