### PR TITLE
fix(xy): the style is invalid when area and line charts are combined

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -133,7 +133,8 @@
             "E":"40",
             "F":"51",
             "G":"31"
-          }' options='{
+          }'
+              options='{
               "theme": "diverging-colors-alerts",
               "legend":{
                 "isLegendClick": true
@@ -262,14 +263,12 @@
                 "categoryAxis": {
                   "gridDisplay":true,
                   "title":"category",
-                  "enableColor":true,
-                  "position":"left"
+                  "enableColor":true
                 },
                 "valueAxis":{
                   "title":"value"
                 },
                 "title":"My First Bar Chart",
-                "theme": "qualitative-colors-primary",
                 "legend":{
                   "isLegendClick": false
                 }
@@ -278,7 +277,7 @@
           </div>
           <div>
             <mdw-xy
-              type="bar"
+              type="column"
               style="width: 40%"
               data='[["Year", "Things", "Stuff"],
               ["2004", 1000, 400],

--- a/src/components/xy-chart/xy-chart.options.ts
+++ b/src/components/xy-chart/xy-chart.options.ts
@@ -5,7 +5,6 @@ const defaultXYChartOptions: XYChartOptions = {
     gridDisplay: true,
     display: true,
     stacked: false,
-    dataKey: '',
   },
   valueAxis: {
     gridDisplay: true,

--- a/src/components/xy-chart/xy-chart.types.ts
+++ b/src/components/xy-chart/xy-chart.types.ts
@@ -3,20 +3,61 @@
  */
 import { TimeUnit } from 'chart.js';
 import { ChartOptions } from '../../types';
+
+/**
+ * Interface `AxisOptions` provides a set of configurations for the axis in a chart.
+ */
 interface AxisOptions {
+  /**
+   * Title of the axis.
+   */
   title?: string;
+  /**
+   * Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart.
+   */
   type?: 'category' | 'time';
+  /**
+   * The location of the axis on the chart.
+   */
   position?: 'left' | 'right' | 'top' | 'bottom' | 'center';
+  /**
+   * Should the data be stacked.
+   */
   stacked?: boolean;
+  /**
+   * Controls the axis global visibility (visible when true, hidden when false)
+   */
   display?: boolean;
+  /**
+   * Controls the grid of axis global visibility (visible when true, hidden when false)
+   */
   gridDisplay?: boolean;
 }
 
+/**
+ * This interface provides options for configuring the category axis.
+ */
 interface CategoryAxisOptions extends AxisOptions {
+  /**
+   * Set to true, the colors of each category of the series are recycled.
+   * Set to false, all categories of each series are one color
+   */
   enableColor?: boolean;
-  dataKey: string;
+  /**
+   *  The category field on the category axis.
+   */
+  dataKey?: string;
+  /**
+   * Specifies the time unit on the category axis.
+   */
   timeUnit?: TimeUnit;
+  /**
+   * Specifies the date format of labels on the category axis.
+   */
   labelFormat?: string;
+  /**
+   * Specifies the format of the tooltip displayed for data points on the category axis.
+   */
   tooltipFormat?: string;
 }
 interface ValueAxisOptions extends AxisOptions {
@@ -24,19 +65,38 @@ interface ValueAxisOptions extends AxisOptions {
 }
 
 export interface XYChartOptions extends ChartOptions {
+  /**
+   * The options for the series.
+   */
   seriesOptions?: {
+    /**
+     * The style mapping is an object where keys are string identifiers.
+     */
     styleMapping: {
       [key: string]: {
-        type?: 'bar' | 'line';
+        type?: 'bar' | 'line' | 'area';
         lineStyle?: 'solid' | 'dashed';
       };
     };
   };
+  /**
+   * Options for configuring the category axis.
+   */
   categoryAxis?: CategoryAxisOptions;
+  /**
+   * Options for configuring the value axis.
+   */
   valueAxis?: ValueAxisOptions;
 }
-// export type DataTableLike = unknown[][] | { cols: unknown[]; rows?: unknown[][] };
+
+/**
+ * The "DataTableLike" type can be a two-dimensional array (unknown[][]) or an array of objects (Record<string, string | number>[]).
+ */
 export type DataTableLike = unknown[][] | Record<string, string | number>[];
+
+/**
+ * Data model required for chart rendering.
+ */
 export type DataView = {
   category: { name?: string; labels?: unknown[] };
   series: {
@@ -45,8 +105,14 @@ export type DataView = {
   }[];
 };
 
+/**
+ * Common data model
+ */
 export interface GenericDataModel {
-  categoryKey?: string;
+  /**
+   *  The category field on the category axis.
+   */
+  dataKey?: string;
   data: {
     [key: string]: string | number;
   }[];


### PR DESCRIPTION
## Description

>Fix the style is invalid when area and line charts are combined.


## Screenshots

- [x] This PR does not have any UI modifications <!-- remove this line and attach the screenshots if you have any UI changes --> 

![image](https://github.com/momentum-design/momentum-widgets/assets/20723412/724a5424-d7c3-4919-acf5-11951ff31b77)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and example
