### PR TITLE
feat(xy): supports dashed area style and label callback

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -12,6 +12,7 @@ export function toChartJSType(type?: string): CJType {
     case ChartType.Area:
     case ChartType.Range:
     case 'dashed':
+    case 'dashedArea':
       chartType = 'line';
       break;
     case ChartType.Pie:

--- a/src/lib/.internal/chart.ts
+++ b/src/lib/.internal/chart.ts
@@ -54,6 +54,7 @@ export abstract class Chart<TData extends ChartData, TOptions extends ChartOptio
 
   resize(): void {
     this.api?.resize();
+    this.legend?.resetSelectedLegendItems();
   }
 
   update(): void {

--- a/src/lib/area/area.ts
+++ b/src/lib/area/area.ts
@@ -1,5 +1,4 @@
 import { ChartDataset } from 'chart.js/auto';
-import 'chartjs-adapter-moment';
 import { alphaColor } from '../../helpers';
 import { ChartType, TableData } from '../../types';
 import { XYChart } from '../xy';
@@ -19,11 +18,16 @@ export class AreaChart extends XYChart {
       color: string;
     },
   ): ChartDataset<'line', number[]> {
-    if (!options?.styleOptions?.type || options?.styleOptions?.type === ChartType.Area) {
+    if (
+      !options?.styleOptions?.type ||
+      options.styleOptions.type === ChartType.Area ||
+      options.styleOptions.type === 'dashedArea'
+    ) {
+      const stacked = this.options?.valueAxes?.[options.styleOptions?.valueAxisIndex ?? 0].stacked;
       dataset.fill = {
         below: alphaColor(options.color, 0.4),
         above: alphaColor(options.color, 0.4),
-        target: 'start',
+        target: stacked ? 'stack' : 'origin',
       };
     }
     return dataset;

--- a/src/lib/bar/bar.ts
+++ b/src/lib/bar/bar.ts
@@ -1,4 +1,3 @@
-import 'chartjs-adapter-moment';
 import { ChartType, TableData } from '../../types';
 import { XYChart } from '../xy';
 

--- a/src/lib/column/column.ts
+++ b/src/lib/column/column.ts
@@ -1,4 +1,3 @@
-import 'chartjs-adapter-moment';
 import { ChartType, TableData } from '../../types';
 import { XYChart } from '../xy';
 

--- a/src/lib/legend/legend.ts
+++ b/src/lib/legend/legend.ts
@@ -44,6 +44,7 @@ export class Legend<TChart extends Chart<ChartData, ChartOptions>> {
     return {
       display: chartOptions.legend?.display ?? true,
       position: chartOptions.legend?.position ?? 'top',
+      reverse: chartOptions.legend?.reverse ?? false,
       labels: {
         usePointStyle: true,
         pointStyle: chartOptions.legend?.markerStyle,

--- a/src/lib/legend/legend.ts
+++ b/src/lib/legend/legend.ts
@@ -153,4 +153,15 @@ export class Legend<TChart extends Chart<ChartData, ChartOptions>> {
       focusBox?.remove();
     }
   }
+
+  public resetSelectedLegendItems(): void {
+    this.selectedItems.forEach((legendItem) => {
+      const cjLegend = this.chart.api?.legend;
+      if (cjLegend) {
+        const index = this.chart.api?.legend?.legendItems?.findIndex((item) => item.text === legendItem.text);
+        cjLegend.chart.canvas.parentElement?.querySelector('#legend-index-' + index)?.remove();
+        this.setItemSelectedStyle(legendItem, cjLegend);
+      }
+    });
+  }
 }

--- a/src/lib/line/line.ts
+++ b/src/lib/line/line.ts
@@ -20,11 +20,15 @@ export class LineChart extends XYChart {
       color: string;
     },
   ): ChartDataset<'line', number[]> {
-    if (options?.styleOptions?.type && options?.styleOptions?.type === ChartType.Area) {
+    if (
+      options?.styleOptions?.type &&
+      (options.styleOptions.type === ChartType.Area || options.styleOptions.type === 'dashedArea')
+    ) {
+      const stacked = this.options?.valueAxes?.[options.styleOptions?.valueAxisIndex ?? 0].stacked;
       dataset.fill = {
         below: alphaColor(options.color, 0.4),
         above: alphaColor(options.color, 0.4),
-        target: 'start',
+        target: stacked ? 'stack' : 'origin',
       };
     }
     return dataset;

--- a/src/lib/range/range.ts
+++ b/src/lib/range/range.ts
@@ -1,5 +1,4 @@
 import { ChartDataset } from 'chart.js/auto';
-import 'chartjs-adapter-moment';
 import { alphaColor } from '../../helpers';
 import { ChartType, TableData } from '../../types';
 import { XYChart } from '../xy';

--- a/src/lib/xy/xy.ts
+++ b/src/lib/xy/xy.ts
@@ -193,7 +193,7 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
             display: this.options.categoryAxis.gridDisplay,
           },
           ticks: {
-            autoSkipPadding: this.options.categoryAxis.ticksPadding || 3,
+            maxTicksLimit: this.options.categoryAxis.maxTicksLimit || 11,
           },
           display: this.options.categoryAxis.display,
         };
@@ -262,7 +262,7 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
             suggestedMax: valueAxis.suggestedMax,
             suggestedMin: valueAxis.suggestedMin,
             ticks: {
-              autoSkipPadding: valueAxis.ticksPadding || 3,
+              maxTicksLimit: valueAxis.maxTicksLimit || 11,
               callback: (tickValue: number | string, index: number) => {
                 return typeof valueAxis.callback === 'function'
                   ? valueAxis.callback(tickValue, index)

--- a/src/lib/xy/xy.types.ts
+++ b/src/lib/xy/xy.types.ts
@@ -1,13 +1,12 @@
 /**
  * The default options for xy chart.
  */
-import { TimeUnit } from 'chart.js';
+import { Tick, TimeUnit } from 'chart.js';
 import { ChartOptions, JsonData, MarkerStyle, TableData } from '../../types';
-
 /**
  * Interface `AxisOptions` provides a set of configurations for the axis in a chart.
  */
-interface AxisOptions {
+export interface AxisOptions {
   /**
    * Title of the axis.
    */
@@ -32,12 +31,22 @@ interface AxisOptions {
    * Controls the grid of axis global visibility (visible when true, hidden when false)
    */
   gridDisplay?: boolean;
-}
 
+  /**
+   * Padding between the ticks on the horizontal axis when autoSkip is enabled.
+   */
+  ticksPadding?: number;
+
+  callback?: (
+    tickValue: number | string,
+    index?: number,
+    ticks?: Tick[],
+  ) => string | string[] | number | number[] | null | undefined;
+}
 /**
  * This interface provides options for configuring the category axis.
  */
-interface CategoryAxisOptions extends AxisOptions {
+export interface CategoryAxisOptions extends AxisOptions {
   /**
    * Set to true, the colors of each category of the series are recycled.
    * Set to false, all categories of each series are one color
@@ -60,20 +69,33 @@ interface CategoryAxisOptions extends AxisOptions {
    */
   tooltipFormat?: string;
 }
-
 export interface ValueAxisOptions extends AxisOptions {
-  callback?: (tickValue: number | string, index: number) => string | string[] | number | number[] | null | undefined;
+  /**
+   * User defined minimum value for the scale, overrides minimum value from data.
+   */
+  min?: number;
+  /**
+   * User defined maximum value for the scale, overrides maximum value from data.
+   */
+  max?: number;
+  /**
+   * Adjustment used when calculating the maximum data value.
+   */
+  suggestedMin?: number;
+  /**
+   * Adjustment used when calculating the minimum data value.
+   */
+  suggestedMax?: number;
 }
 
 export interface SeriesStyleOptions {
-  type?: 'bar' | 'line' | 'area' | 'dashed';
+  type?: 'bar' | 'line' | 'area' | 'dashed' | 'dashedArea';
   valueAxisIndex?: number;
   tension?: number;
   order?: number;
   markerStyle?: MarkerStyle;
   fillGaps?: boolean;
 }
-
 export interface XYChartOptions extends ChartOptions {
   /**
    * The options for the series.
@@ -95,7 +117,6 @@ export interface XYChartOptions extends ChartOptions {
    */
   valueAxes?: ValueAxisOptions[];
 }
-
 /**
  * The "DataTableLike" type can be a two-dimensional array (unknown[][]) or an array of objects (Record<string, string | number>[]).
  */

--- a/src/lib/xy/xy.types.ts
+++ b/src/lib/xy/xy.types.ts
@@ -33,9 +33,9 @@ export interface AxisOptions {
   gridDisplay?: boolean;
 
   /**
-   * Padding between the ticks on the horizontal axis when autoSkip is enabled.
+   * Maximum number of ticks and gridlines to show.
    */
-  ticksPadding?: number;
+  maxTicksLimit?: number;
 
   callback?: (
     tickValue: number | string,

--- a/src/types/chart.legend.types.ts
+++ b/src/types/chart.legend.types.ts
@@ -15,6 +15,7 @@ export interface LegendOptions {
   onItemClick?(event: ChartEvent<LegendItem>): void;
   display?: boolean;
   position?: Position;
+  reverse?: boolean;
   markerStyle?: MarkerStyle;
   tooltip?: TooltipOptions;
   states?: {


### PR DESCRIPTION
## Description

> The label of the chart axis supports callback to modify the display results.
> Chart series has added the situation where area and dashed styles exist at the same time.
> XY Chart has added some new configurations and optimized some display effects.
> Fixed no resize canvas when resizing chart.


## Screenshots

![image](https://github.com/momentum-design/momentum-widgets/assets/20723412/4d2f2215-e94d-44af-bbc0-c45c8c4bc222)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and example
