### PR TITLE
fix(legend): position is offset when the parent element has padding

### DIFF
--- a/src/lib/legend/legend.ts
+++ b/src/lib/legend/legend.ts
@@ -48,6 +48,7 @@ export class Legend<TChart extends Chart<ChartData, ChartOptions>> {
       labels: {
         usePointStyle: true,
         pointStyle: chartOptions.legend?.markerStyle,
+        font: { size: 12 },
         generateLabels: (chart: CJ<CJChartType>) => {
           let gl = CJ.defaults.plugins.legend.labels.generateLabels;
           if (typeof opts?.generateLabels === 'function') {
@@ -129,21 +130,28 @@ export class Legend<TChart extends Chart<ChartData, ChartOptions>> {
   private setItemSelectedStyle(legendItem: LegendItem, cjLegend: CJLegendElement<CJChartType>): void {
     const index = cjLegend.legendItems?.findIndex((item) => item.text === legendItem.text);
     let focusBox = cjLegend.chart.canvas.parentElement?.querySelector('#legend-index-' + index);
+    if (!cjLegend.chart.canvas.parentElement) {
+      return;
+    }
     if (legendItem.selected) {
       if (!focusBox) {
         focusBox = document.createElement('div');
         focusBox.setAttribute('id', 'legend-index-' + index);
       }
+      const canvasRect = cjLegend.chart.canvas.getBoundingClientRect();
+      const parentRect = cjLegend.chart.canvas.parentElement?.getBoundingClientRect();
+      const leftOffset = canvasRect.left - parentRect.left;
+      const topOffset = canvasRect.top - parentRect.top;
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const { left, top, width, height } = cjLegend.legendHitBoxes[index];
-      const newLeft = `${left - 7}px`;
-      const newTop = `${top - 3}px`;
+      const newLeft = `${left - 7 + leftOffset}px`;
+      const newTop = `${top - 4 + topOffset}px`;
       const newWidth = `${width + 14}px`;
-      const newHeight = `${height + 6}px`;
+      const newHeight = `${height + 8}px`;
       focusBox.setAttribute(
         'style',
-        `pointer-events:none;position:absolute; background-color:#2b2b2b1a; border-radius: 10px;left: ${newLeft}; top:${newTop}; width:${newWidth}; height:${newHeight}`,
+        `left:${newLeft};top:${newTop};width:${newWidth};height:${newHeight};background-color:#2b2b2b1a;pointer-events:none;position:absolute;border-radius:10px;`,
       );
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/lib/xy/xy.ts
+++ b/src/lib/xy/xy.ts
@@ -192,7 +192,10 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
           grid: {
             display: this.options.categoryAxis.gridDisplay,
           },
+          max: this.options.categoryAxis.max,
+          min: this.options.categoryAxis.min,
           ticks: {
+            autoSkipPadding: this.options.categoryAxis.ticksPadding || 3,
             maxTicksLimit: this.options.categoryAxis.maxTicksLimit || 11,
           },
           display: this.options.categoryAxis.display,
@@ -262,6 +265,7 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
             suggestedMax: valueAxis.suggestedMax,
             suggestedMin: valueAxis.suggestedMin,
             ticks: {
+              autoSkipPadding: valueAxis.ticksPadding || 3,
               maxTicksLimit: valueAxis.maxTicksLimit || 11,
               callback: (tickValue: number | string, index: number) => {
                 return typeof valueAxis.callback === 'function'
@@ -403,7 +407,6 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
       },
       series: [],
     };
-
     if (!data?.dataKey) {
       return result;
     }

--- a/src/lib/xy/xy.types.ts
+++ b/src/lib/xy/xy.types.ts
@@ -31,11 +31,22 @@ export interface AxisOptions {
    * Controls the grid of axis global visibility (visible when true, hidden when false)
    */
   gridDisplay?: boolean;
-
   /**
    * Maximum number of ticks and gridlines to show.
    */
   maxTicksLimit?: number;
+  /**
+   * Padding between the ticks on the horizontal axis when autoSkip is enabled.
+   */
+  ticksPadding?: number;
+  /**
+   * User defined minimum value for the scale, overrides minimum value from data.
+   */
+  min?: number;
+  /**
+   * User defined maximum value for the scale, overrides maximum value from data.
+   */
+  max?: number;
 
   callback?: (
     tickValue: number | string,
@@ -70,14 +81,6 @@ export interface CategoryAxisOptions extends AxisOptions {
   tooltipFormat?: string;
 }
 export interface ValueAxisOptions extends AxisOptions {
-  /**
-   * User defined minimum value for the scale, overrides minimum value from data.
-   */
-  min?: number;
-  /**
-   * User defined maximum value for the scale, overrides maximum value from data.
-   */
-  max?: number;
   /**
    * Adjustment used when calculating the maximum data value.
    */


### PR DESCRIPTION
## Description

> Fix the legend position being shifted when the parent element has padding.

## Screenshots

- [x] This PR does not have any UI modifications <!-- remove this line and attach the screenshots if you have any UI changes --> 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and example
