### PR TITLE
fix(xy): legend icon size is inconsistent after setting markerStyle

### DIFF
--- a/src/lib/xy/xy.ts
+++ b/src/lib/xy/xy.ts
@@ -415,7 +415,7 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
     const seriesData = seriesNames.map((name) => {
       return {
         name: name,
-        data: data.data.map((item) => (item[name] as number) || null),
+        data: data.data.map((item) => (item[name] as number) ?? null),
       };
     });
 

--- a/src/lib/xy/xy.ts
+++ b/src/lib/xy/xy.ts
@@ -134,6 +134,7 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
             labels.map((label) => {
               if (this.options.legend?.markerStyle) {
                 label.pointStyle = this.options.legend?.markerStyle;
+                label.lineWidth = 0;
                 return label;
               }
               let dataset = chart.data.datasets.find((dataset) => dataset.label === label.text);

--- a/src/lib/xy/xy.ts
+++ b/src/lib/xy/xy.ts
@@ -274,9 +274,9 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
                   ? this.formatBigNumber(tickValue as number)
                   : tickValue;
               },
+              stepSize: valueAxis.ticksStepSize,
             },
           },
-          // TODO(yiwei): stepSize.  { tick: { stepSize: 1 } },
           { position: valueAxis.position },
         );
       });

--- a/src/lib/xy/xy.types.ts
+++ b/src/lib/xy/xy.types.ts
@@ -47,6 +47,10 @@ export interface AxisOptions {
    * User defined maximum value for the scale, overrides maximum value from data.
    */
   max?: number;
+  /**
+   * User defined fixed step size for the scale
+   */
+  ticksStepSize?: number;
 
   callback?: (
     tickValue: number | string,


### PR DESCRIPTION
## Description

> Fix value is not displayed when it is 0
> Customize the interval value for each tick
> Legend icon size is inconsistent after setting markerStyle 

## Screenshots

- [x] This PR does not have any UI modifications <!-- remove this line and attach the screenshots if you have any UI changes --> 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and example
