### PR TITLE
docs(website): add shortcut buttons to examples and improve wiki

### DIFF
--- a/src/lib/xy/xy.types.ts
+++ b/src/lib/xy/xy.types.ts
@@ -41,18 +41,20 @@ export interface AxisOptions {
    */
   autoSkip?: boolean;
   /**
-   * Padding between the ticks on the horizontal axis when autoSkip is enabled.
+   * Padding between ticks on the horizontal or vertical axis.                                                                                                                                                               .
    */
   ticksPadding?: number;
   /**
-   * User defined fixed step size for the scale
+   * User defined fixed step size for the axis.
    */
   ticksStepSize?: number;
   /**
-   * Color of tick
+   * Label color of tick.
    */
   labelColor?: string | string[];
-
+  /**
+   * Returns the string representation of the tick values that should be displayed on the chart.
+   */
   callback?: (
     tickValue: number | string,
     index?: number,
@@ -84,12 +86,19 @@ export interface CategoryAxisOptions extends AxisOptions {
    * Specifies the format of the tooltip displayed for data points on the category axis.
    */
   tooltipFormat?: string;
-
+  /**
+   * The maximum number of ticks displayed.
+   */
   maxLabels?: number;
   /**
    * The supported type is category, but time is not supported.
    */
   labelSelectable?: boolean;
+  /**
+   * Returns the currently selected label and all selected labels.
+   * @param label The currently selected label
+   * @param selectedLabels All selected labels
+   */
   onLabelClick?(label: string | undefined, selectedLabels?: string[]): void;
 }
 export interface ValueAxisOptions extends AxisOptions {
@@ -112,11 +121,29 @@ export interface ValueAxisOptions extends AxisOptions {
 }
 
 export interface SeriesStyleOptions {
+  /**
+   * The chart type of the series, if not set, it will be the same as the global type.
+   */
   type?: 'bar' | 'line' | 'area' | 'dashed' | 'dashedArea';
+  /**
+   * The index of the value axis.
+   */
   valueAxisIndex?: number;
+  /**
+   * Bezier curve tension (0 means no bezier curve).
+   */
   tension?: number;
+  /**
+   * The drawing order of dataset. Also affects order for stacking, tooltip and legend.
+   */
   order?: number;
+  /**
+   * Style of the point.
+   */
   markerStyle?: MarkerStyle;
+  /**
+   * If true, lines will be drawn between points with no or null data. If false, points with NaN data will create a break in the line. Can also be a number specifying the maximum gap length to span. The unit of the value depends on the scale used.
+   */
   fillGaps?: boolean;
 }
 export interface XYChartOptions extends ChartOptions {

--- a/website/docs/tutorials/charts/area.mdx
+++ b/website/docs/tutorials/charts/area.mdx
@@ -6,43 +6,89 @@ sidebar_position: 108
 
 Area chart support a fill area on the dataset object which can be used to create space between a dataset and a boundary.
 
-```jsx live
-function showComponent() {
-  const data = [
-    ['Year', 'Area', 'Line'],
-    ['2016', 3000, 4000],
-    ['2017', 8700, 4600],
-    ['2018', 6600, 1200],
-    ['2019', 5300, 5400],
-    ['2020', 4300, 3400],
-    ['2021', 6300, 8400],
-    ['2022', 7300, 4400],
-    ['2023', 7300, 7400],
-  ];
-  const options = {
-    seriesOptions: {
-      styleMapping: {
-        Line: {
-          type: 'line',
-          tension: 0.3,
-        },
-        Area: {
-          tension: 0.3,
-        },
+```jsx live noInline
+const data = [
+  ['Year', 'Area', 'Line'],
+  ['2016', 3000, 4000],
+  ['2017', 8700, 4600],
+  ['2018', 6600, 1200],
+  ['2019', 5300, 5400],
+  ['2020', 4300, 3400],
+  ['2021', 6300, 8400],
+  ['2022', 7300, 4400],
+  ['2023', 7300, 7400],
+];
+const initialOptions = {
+  seriesOptions: {
+    styleMapping: {
+      Line: {
+        tension: 0.3,
+      },
+      Area: {
+        tension: 0.3,
       },
     },
-  };
-  return (
-    <div>
-      <mdw-chart
-        type="area"
-        style={{ height: '300px' }}
-        data={JSON.stringify(data)}
-        options={JSON.stringify(options)}
-      ></mdw-chart>
-    </div>
-  );
-}
+  },
+};
+const Example = () =>
+  getExample(initialOptions, data, ({ key, data, options, setOptions }) => {
+    const Buttons = () => (
+      <>
+        <Button onClick={() => setOptions(initialOptions)}>All Area</Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                seriesOptions: {
+                  styleMapping: {
+                    Line: {
+                      type: 'line',
+                    },
+                  },
+                },
+              },
+              false,
+            )
+          }
+        >
+          Single Area
+        </Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                seriesOptions: {
+                  styleMapping: {
+                    Area: {
+                      type: 'dashedArea',
+                    },
+                  },
+                },
+              },
+              false,
+            )
+          }
+        >
+          Dashed Area
+        </Button>
+        {buttonsRelatedToColor(setOptions)}
+      </>
+    );
+
+    return (
+      <WithActions buttons={<Buttons />}>
+        <mdw-chart
+          key={key}
+          style={{ height: '300px' }}
+          type="area"
+          data={JSON.stringify(data)}
+          options={JSON.stringify(options)}
+        ></mdw-chart>
+      </WithActions>
+    );
+  });
+
+render(<Example />);
 ```
 
 ## Type
@@ -51,62 +97,8 @@ type = 'area'
 
 ## Data
 
-The data supports the following multiple data formats:
-
-| Mode                  | Type                               | Example                                                                                                                  |
-| --------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Two-dimensional array | unknown[][]                        | [['Year','Things'],['2004',1000],['2005',1170],['2006',660],['2007',1030]]                                               |
-| Array                 | Record<string, string \| number>[] | [{"Year":"2004","Things":1000},{"Year":"2005","Things":1170},{"Year":"2006","Things":660},{"Year":"2007","Things":1030}] |
+See [Bar Chart](./bar#data)
 
 ## Options
 
-| Name          | Type                                        | Description                                           |
-| ------------- | ------------------------------------------- | ----------------------------------------------------- |
-| seriesOptions | [SeriesOptions](#seriesoptions)             | Series related configuration, including styleMapping. |
-| categoryAxis  | [CategoryAxisOptions](#categoryaxisoptions) | Used to create a category-based axis for the chart.   |
-| valueAxis     | [ValueAxisOptions](#valueaxisoptions)       | Used to create a value axis for the chart.            |
-
-### AxisOptions
-
-These are only the common options supported by all axes. Please see specific axis documentation for all the available options for that axis.
-
-| Name        | Type                                               | Default | Description                                                                                                                                        |
-| ----------- | -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title       | `string`                                           |         | Title of value axis.                                                                                                                               |
-| type        | `category` \| `time`                               |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart. |
-| position    | `left` \| `right` \| `top` \| `bottom` \| `center` |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.             |
-| display     | `boolean`                                          | `true`  | Controls the axis global visibility (visible when true, hidden when false).                                                                        |
-| gridDisplay | `boolean`                                          | `true`  | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                |
-| stacked     | `boolean`                                          | `false` | Should the data be stacked.                                                                                                                        |
-
-### SeriesOptions
-
-The options for the series.
-
-| Name         | Type                          | Default | Description                                                       |
-| ------------ | ----------------------------- | ------- | ----------------------------------------------------------------- |
-| styleMapping | [styleMapping](#stylemapping) |         | The style mapping is an object where keys are string identifiers. |
-
-#### styleMapping
-
-| Name      | Type                | Default | Description                                                                       |
-| --------- | ------------------- | ------- | --------------------------------------------------------------------------------- |
-| key       | `string`            |         | Series name.                                                                      |
-| type      | `line` \| `area`    |         | The chart type of the series, if not set, it will be the same as the global type. |
-| lineStyle | `solid` \| `dashed` | `solid` | The line style of the series                                                      |
-
-### CategoryAxisOptions
-
-CategoryAxisOptions extends [AxisOptions](#axisoptions)
-
-| Name          | Type                                                                                                 | Default | Description                                                                                                                                                  |
-| ------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| enableColor   | `boolean`                                                                                            | `false` |                                                                                                                                                              |
-| dataKey       | `string`                                                                                             |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
-| timeUnit      | `millisecond` \| `second` \| `minute` \| `hour` \| `day` \| `week` \| `month` \| `quarter` \| `year` |         | Specifies the time unit on the category axis.                                                                                                                |
-| labelFormat   | `string`                                                                                             |         | Specifies the date format of labels on the category axis. See chartjs-adapter-moment                                                                         |
-| tooltipFormat | `string`                                                                                             |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
-
-### ValueAxisOptions
-
-ValueAxisOptions extends [AxisOptions](#axisoptions)
+See [Bar Chart](./bar#options)

--- a/website/docs/tutorials/charts/bar.mdx
+++ b/website/docs/tutorials/charts/bar.mdx
@@ -6,76 +6,115 @@ sidebar_position: 104
 
 Bar chart provides a way of showing data values represented as horizontal bars. It is sometimes used to show trend data, and the comparison of multiple data sets side by side.
 
-```jsx live
-function showComponent() {
-  const data = [
-    {
-      country: 'USA',
-      value: 2025,
-    },
-    {
-      country: 'China',
-      value: 1882,
-    },
-    {
-      country: 'Japan',
-      value: 1809,
-    },
-    {
-      country: 'Germany',
-      value: 1322,
-    },
-    {
-      country: 'UK',
-      value: 1122,
-    },
-    {
-      country: 'France',
-      value: 1114,
-    },
-    {
-      country: 'India',
-      value: 984,
-    },
-    {
-      country: 'Spain',
-      value: 711,
-    },
-    {
-      country: 'Netherlands',
-      value: 665,
-    },
-    {
-      country: 'South Korea',
-      value: 443,
-    },
-    {
-      country: 'Canada',
-      value: 441,
-    },
-  ];
-  const options = {
-    scrollable: true,
-    categoryAxis: {
-      labelSelectable: true,
-      gridDisplay: true,
-      enableColor: true,
-      dataKey: 'country',
-      maxLabels: 6,
-    },
-    legend: {},
-  };
-  return (
-    <div>
-      <mdw-chart
-        type="bar"
-        style={{ height: '300px' }}
-        data={JSON.stringify(data)}
-        options={JSON.stringify(options)}
-      ></mdw-chart>
-    </div>
-  );
-}
+```jsx live noInline
+const data = [
+  {
+    country: 'USA',
+    value: 2025,
+  },
+  {
+    country: 'China',
+    value: 1882,
+  },
+  {
+    country: 'Japan',
+    value: 1809,
+  },
+  {
+    country: 'Germany',
+    value: 1322,
+  },
+  {
+    country: 'UK',
+    value: 1122,
+  },
+  {
+    country: 'France',
+    value: 1114,
+  },
+  {
+    country: 'India',
+    value: 984,
+  },
+  {
+    country: 'Spain',
+    value: 711,
+  },
+  {
+    country: 'Netherlands',
+    value: 665,
+  },
+  {
+    country: 'South Korea',
+    value: 443,
+  },
+  {
+    country: 'Canada',
+    value: 441,
+  },
+];
+const initialOptions = {
+  scrollable: true,
+  categoryAxis: {
+    labelSelectable: false,
+    gridDisplay: true,
+    enableColor: true,
+    dataKey: 'country',
+    maxLabels: 6,
+  },
+  legend: {},
+};
+const Example = () =>
+  getExample(initialOptions, data, ({ key, data, options, setOptions }) => {
+    const Buttons = () => (
+      <>
+        <Button onClick={() => setOptions(initialOptions)}>Default</Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                categoryAxis: {
+                  enableColor: false,
+                },
+              },
+              false,
+            )
+          }
+        >
+          Single Color
+        </Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                categoryAxis: {
+                  labelSelectable: true,
+                },
+              },
+              false,
+            )
+          }
+        >
+          Toggle Label Select
+        </Button>
+        {buttonsRelatedToColor(setOptions)}
+      </>
+    );
+
+    return (
+      <WithActions buttons={<Buttons />}>
+        <mdw-chart
+          key={key}
+          style={{ height: '300px' }}
+          type="bar"
+          data={JSON.stringify(data)}
+          options={JSON.stringify(options)}
+        ></mdw-chart>
+      </WithActions>
+    );
+  });
+
+render(<Example />);
 ```
 
 ## Type
@@ -86,31 +125,39 @@ type = 'bar'
 
 The data supports the following multiple data formats:
 
-| Mode                  | Type                               | Example                                                                                                                  |
-| --------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Two-dimensional array | unknown[][]                        | [['Year','Things'],['2004',1000],['2005',1170],['2006',660],['2007',1030]]                                               |
-| Array                 | Record<string, string \| number>[] | [{"Year":"2004","Things":1000},{"Year":"2005","Things":1170},{"Year":"2006","Things":660},{"Year":"2007","Things":1030}] |
+| Mode                  | Type                               | Example                                                           |
+| --------------------- | ---------------------------------- | ----------------------------------------------------------------- |
+| Two-dimensional array | unknown[][]                        | [['Year','Things'],['2004',1000],...]                             |
+| Array                 | Record<string, string \| number>[] | [{"Year":"2004","Things":1000},{"Year":"2005","Things":1170},...] |
 
 ## Options
 
-| Name          | Type                                        | Description                                           |
-| ------------- | ------------------------------------------- | ----------------------------------------------------- |
-| seriesOptions | [SeriesOptions](#seriesoptions)             | Series related configuration, including styleMapping. |
-| categoryAxis  | [CategoryAxisOptions](#categoryaxisoptions) | Used to create a category-based axis for the chart.   |
-| valueAxis     | [ValueAxisOptions](#valueaxisoptions)       | Used to create a value axis for the chart.            |
+| Name            | Type                                        | Description                                           |
+| --------------- | ------------------------------------------- | ----------------------------------------------------- |
+| seriesOptions   | [SeriesOptions](#seriesoptions)             | Series related configuration, including styleMapping. |
+| categoryAxis    | [CategoryAxisOptions](#categoryaxisoptions) | Used to create a category-based axis for the chart.   |
+| valueAxis       | [ValueAxisOptions](#valueaxisoptions)       | Used to create a value axis for the chart.            |
+| scrollable      | `boolean`                                   | If true, chart supports scrolling.                    |
+| scrollDirection | `x` \| `y` \| `xy`                          | The direction of chart scrolling.                     |
 
 ### AxisOptions
 
 These are only the common options supported by all axes. Please see specific axis documentation for all the available options for that axis.
 
-| Name        | Type                                               | Default | Description                                                                                                                                        |
-| ----------- | -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title       | `string`                                           |         | Title of value axis.                                                                                                                               |
-| type        | `category` \| `time`                               |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart. |
-| position    | `left` \| `right` \| `top` \| `bottom` \| `center` |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.             |
-| display     | `boolean`                                          | `true`  | Controls the axis global visibility (visible when true, hidden when false).                                                                        |
-| gridDisplay | `boolean`                                          | `true`  | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                |
-| stacked     | `boolean`                                          | `false` | Should the data be stacked.                                                                                                                        |
+| Name          | Type                    | Default | Description                                                                                                                                                                                                     |
+| ------------- | ----------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title         | `string`                |         | Title of value axis.                                                                                                                                                                                            |
+| type          | `category` \| `time`    |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart.                                                              |
+| position      | `Position`              |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.                                                                          |
+| stacked       | `boolean`               | `false` | Should the data be stacked.                                                                                                                                                                                     |
+| display       | `boolean`               | `true`  | Controls the axis global visibility (visible when true, hidden when false).                                                                                                                                     |
+| gridDisplay   | `boolean`               | `true`  | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                                                                             |
+| maxTicksLimit | `number`                |         | Maximum number of ticks and gridlines to show.                                                                                                                                                                  |
+| autoSkip      | `boolean`               | `true`  | If true, automatically calculates how many labels can be shown and hides labels accordingly. Labels will be rotated up to maxRotation before skipping any. Turn autoSkip off to show all labels no matter what. |
+| ticksPadding  | `number`                |         | Padding between ticks on the horizontal or vertical axis.                                                                                                                                                       |
+| ticksStepSize | `number`                |         | User defined fixed step size for the axis.                                                                                                                                                                      |
+| labelColor    | ` string` \| `string[]` |         | Label color of tick.                                                                                                                                                                                            |
+| callback      | `function`              |         | Returns the string representation of the tick values that should be displayed on the chart.                                                                                                                     |
 
 ### SeriesOptions
 
@@ -122,23 +169,30 @@ The options for the series.
 
 #### styleMapping
 
-| Name      | Type                      | Default | Description                                                                       |
-| --------- | ------------------------- | ------- | --------------------------------------------------------------------------------- |
-| key       | `string`                  |         | Series name.                                                                      |
-| type      | `bar` \| `line` \| `area` |         | The chart type of the series, if not set, it will be the same as the global type. |
-| lineStyle | `solid` \| `dashed`       | `solid` | The line style of the series                                                      |
+| Name           | Type                                                  | Default | Description                                                                                                                                                                                                                                        |
+| -------------- | ----------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key            | `string`                                              |         | Series name.                                                                                                                                                                                                                                       |
+| type           | `bar` \| `line` \| `area` \| `dashed` \| `dashedArea` |         | The chart type of the series, if not set, it will be the same as the global type.                                                                                                                                                                  |
+| valueAxisIndex | `number`                                              |         | The index of the value axis.                                                                                                                                                                                                                       |
+| tension        | `number`                                              |         | Bezier curve tension (0 means no bezier curve).                                                                                                                                                                                                    |
+| order          | `number`                                              |         | The drawing order of dataset. Also affects order for stacking, tooltip and legend.                                                                                                                                                                 |
+| markerStyle    | `MarkerStyle`                                         |         | Style of the point.                                                                                                                                                                                                                                |
+| fillGaps       | `boolean`                                             |         | If true, lines will be drawn between points with no or null data. If false, points with NaN data will create a break in the line. Can also be a number specifying the maximum gap length to span. The unit of the value depends on the scale used. |
 
 ### CategoryAxisOptions
 
 CategoryAxisOptions extends [AxisOptions](#axisoptions)
 
-| Name          | Type                                                                                                 | Default | Description                                                                                                                                                  |
-| ------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| enableColor   | `boolean`                                                                                            | `false` |                                                                                                                                                              |
-| dataKey       | `string`                                                                                             |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
-| timeUnit      | `millisecond` \| `second` \| `minute` \| `hour` \| `day` \| `week` \| `month` \| `quarter` \| `year` |         | Specifies the time unit on the category axis.                                                                                                                |
-| labelFormat   | `string`                                                                                             |         | Specifies the date format of labels on the category axis. See chartjs-adapter-moment                                                                         |
-| tooltipFormat | `string`                                                                                             |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
+| Name            | Type       | Default | Description                                                                                                                                                  |
+| --------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| enableColor     | `boolean`  | `false` |                                                                                                                                                              |
+| dataKey         | `string`   |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
+| timeUnit        | `TimeUnit` |         | Specifies the time unit on the category axis.                                                                                                                |
+| labelFormat     | `string`   |         | Specifies the date format of labels on the category axis. See chartjs-adapter-moment                                                                         |
+| tooltipFormat   | `string`   |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
+| maxLabels       | `number`   |         | The maximum number of ticks displayed.                                                                                                                       |
+| labelSelectable | `boolean`  |         | If true, label supports multiple selections.                                                                                                                 |
+| onLabelClick    | `function` |         | Returns the currently selected label and all selected labels.                                                                                                |
 
 ### ValueAxisOptions
 

--- a/website/docs/tutorials/charts/column.mdx
+++ b/website/docs/tutorials/charts/column.mdx
@@ -6,174 +6,170 @@ sidebar_position: 105
 
 Column chart provides a way of showing data values represented as vertical bars. It is sometimes used to show trend data, and the comparison of multiple data sets side by side.
 
-```jsx live
-function showComponent() {
-  const data = [
+```jsx live noInline
+const data = [
+  {
+    date: 'January',
+    'New Mexico': 8757,
+    Florida: 5588,
+    Nevada: 7370,
+    Wyoming: 8478,
+    Arkansas: 2174,
+  },
+  {
+    date: 'February',
+    'New Mexico': 2602,
+    Florida: 8134,
+    Nevada: 198,
+    Wyoming: 1204,
+    Arkansas: 894,
+  },
+  {
+    date: 'March',
+    'New Mexico': 4191,
+    Florida: 3375,
+    Nevada: 3473,
+    Wyoming: 6359,
+    Arkansas: 7669,
+  },
+  {
+    date: 'April',
+    'New Mexico': 7684,
+    Florida: 8590,
+    Nevada: 3483,
+    Wyoming: 792,
+    Arkansas: 9651,
+  },
+  {
+    date: 'May',
+    'New Mexico': 5332,
+    Florida: 5670,
+    Nevada: 3803,
+    Wyoming: 8538,
+    Arkansas: 7468,
+  },
+  {
+    date: 'June',
+    'New Mexico': 8579,
+    Florida: 627,
+    Nevada: 1531,
+    Wyoming: 6598,
+    Arkansas: 3762,
+  },
+  {
+    date: 'July',
+    'New Mexico': 3409,
+    Florida: 2120,
+    Nevada: 7987,
+    Wyoming: 6407,
+    Arkansas: 6416,
+  },
+  {
+    date: 'August',
+    'New Mexico': 5513,
+    Florida: 6070,
+    Nevada: 3558,
+    Wyoming: 351,
+    Arkansas: 8387,
+  },
+  {
+    date: 'September',
+    'New Mexico': 1015,
+    Florida: 4560,
+    Nevada: 6241,
+    Wyoming: 6344,
+    Arkansas: 7394,
+  },
+  {
+    date: 'October',
+    'New Mexico': 3060,
+    Florida: 5139,
+    Nevada: 7757,
+    Wyoming: 3808,
+    Arkansas: 5121,
+  },
+  {
+    date: 'November',
+    'New Mexico': 4060,
+    Florida: 7139,
+    Nevada: 8757,
+    Wyoming: 5808,
+    Arkansas: 3121,
+  },
+  {
+    date: 'December',
+    'New Mexico': 5060,
+    Florida: 7139,
+    Nevada: 10757,
+    Wyoming: 6808,
+    Arkansas: 2121,
+  },
+];
+const initialOptions = {
+  categoryAxis: {
+    stacked: false,
+    enableColor: false,
+    dataKey: 'date',
+    autoSkip: false,
+  },
+  valueAxes: [
     {
-      date: 'January',
-      'New Mexico': 8757,
-      Florida: 5588,
-      Nevada: 7370,
-      Wyoming: 8478,
-      Arkansas: 2174,
-    },
-    {
-      date: 'February',
-      'New Mexico': 2602,
-      Florida: 8134,
-      Nevada: 198,
-      Wyoming: 1204,
-      Arkansas: 894,
-    },
-    {
-      date: 'March',
-      'New Mexico': 4191,
-      Florida: 3375,
-      Nevada: 3473,
-      Wyoming: 6359,
-      Arkansas: 7669,
-    },
-    {
-      date: 'April',
-      'New Mexico': 7684,
-      Florida: 8590,
-      Nevada: 3483,
-      Wyoming: 792,
-      Arkansas: 9651,
-    },
-    {
-      date: 'May',
-      'New Mexico': 5332,
-      Florida: 5670,
-      Nevada: 3803,
-      Wyoming: 8538,
-      Arkansas: 7468,
-    },
-    {
-      date: 'June',
-      'New Mexico': 8579,
-      Florida: 627,
-      Nevada: 1531,
-      Wyoming: 6598,
-      Arkansas: 3762,
-    },
-    {
-      date: 'July',
-      'New Mexico': 3409,
-      Florida: 2120,
-      Nevada: 7987,
-      Wyoming: 6407,
-      Arkansas: 6416,
-    },
-    {
-      date: 'August',
-      'New Mexico': 5513,
-      Florida: 6070,
-      Nevada: 3558,
-      Wyoming: 351,
-      Arkansas: 8387,
-    },
-    {
-      date: 'September',
-      'New Mexico': 1015,
-      Florida: 4560,
-      Nevada: 6241,
-      Wyoming: 6344,
-      Arkansas: 7394,
-    },
-    {
-      date: 'October',
-      'New Mexico': 3060,
-      Florida: 5139,
-      Nevada: 7757,
-      Wyoming: 3808,
-      Arkansas: 5121,
-    },
-    {
-      date: 'November',
-      'New Mexico': 4060,
-      Florida: 7139,
-      Nevada: 8757,
-      Wyoming: 5808,
-      Arkansas: 3121,
-    },
-    {
-      date: 'December',
-      'New Mexico': 5060,
-      Florida: 7139,
-      Nevada: 10757,
-      Wyoming: 6808,
-      Arkansas: 2121,
-    },
-  ];
-  const initialOptions = {
-    categoryAxis: {
       stacked: false,
-      enableColor: false,
-      dataKey: 'date',
-      ticksPadding: 80,
     },
-    valueAxes: [
-      {
-        stacked: false,
-      },
-    ],
-  };
+  ],
+};
+const Example = () =>
+  getExample(initialOptions, data, ({ key, data, options, setOptions }) => {
+    const Buttons = () => (
+      <>
+        <Button onClick={() => setOptions(initialOptions)}>No Stacked</Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                categoryAxis: { stacked: true },
+                valueAxes: [{ stacked: false }],
+              },
+              false,
+            )
+          }
+        >
+          Category Stacked
+        </Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                categoryAxis: { stacked: false },
+                valueAxes: [{ stacked: true }],
+              },
+              false,
+            )
+          }
+        >
+          Value Stacked
+        </Button>
+        <Button onClick={() => setOptions({ categoryAxis: { stacked: true }, valueAxes: [{ stacked: true }] })}>
+          All Stacked
+        </Button>
+        {buttonsRelatedToColor(setOptions)}
+      </>
+    );
 
-  const [options, setOptions] = useState(initialOptions);
-  const [key, setKey] = useState(new Date().getTime());
-  const handleButtonClick = (type) => {
-    setKey((preKey) => {
-      return new Date().getTime();
-    });
-    setOptions(() => {
-      const prevOptions = { ...initialOptions };
-      if (type === 'category') {
-        prevOptions.categoryAxis.stacked = !prevOptions.categoryAxis.stacked;
-      } else if (type === 'value') {
-        prevOptions.valueAxes[0].stacked = !prevOptions.valueAxes[0].stacked;
-      } else if (type === 'all') {
-        prevOptions.categoryAxis.stacked = !prevOptions.categoryAxis.stacked;
-        prevOptions.valueAxes[0].stacked = !prevOptions.valueAxes[0].stacked;
-      }
-      return {
-        ...prevOptions,
-      };
-    });
-  };
-  const actionStyle = {
-    padding: '8px 16px',
-    margin: '0 8px 8px 0',
-    borderRadius: '6px',
-    color: '#3080d0',
-    cursor: 'pointer',
-    background: 'rgba(48,128,208,.15)',
-    borderColor: 'rgba(48,128,208,.2)',
-  };
-  return (
-    <div>
-      <mdw-chart
-        key={key}
-        style={{ height: '300px' }}
-        type="column"
-        data={JSON.stringify(data)}
-        options={JSON.stringify(options)}
-      ></mdw-chart>
-      <button style={actionStyle} onClick={handleButtonClick}>
-        Default
-      </button>
-      <button style={actionStyle} onClick={() => handleButtonClick('category')}>
-        Category Stacked
-      </button>
-      <button style={actionStyle} onClick={() => handleButtonClick('value')}>
-        Value Stacked
-      </button>
-      <button style={actionStyle} onClick={() => handleButtonClick('all')}>
-        All Stacked
-      </button>
-    </div>
-  );
-}
+    return (
+      <WithActions buttons={<Buttons />}>
+        <mdw-chart
+          key={key}
+          style={{ height: '300px' }}
+          type="column"
+          data={JSON.stringify(data)}
+          options={JSON.stringify(options)}
+        ></mdw-chart>
+      </WithActions>
+    );
+  });
+
+render(<Example />);
 ```
 
 ## Type
@@ -182,62 +178,8 @@ type = 'column'
 
 ## Data
 
-The data supports the following multiple data formats:
-
-| Mode                  | Type                               | Example                                                                                                                  |
-| --------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Two-dimensional array | unknown[][]                        | [['Year','Things'],['2004',1000],['2005',1170],['2006',660],['2007',1030]]                                               |
-| Array                 | Record<string, string \| number>[] | [{"Year":"2004","Things":1000},{"Year":"2005","Things":1170},{"Year":"2006","Things":660},{"Year":"2007","Things":1030}] |
+See [Bar Chart](./bar#data)
 
 ## Options
 
-| Name          | Type                                        | Description                                           |
-| ------------- | ------------------------------------------- | ----------------------------------------------------- |
-| seriesOptions | [SeriesOptions](#seriesoptions)             | Series related configuration, including styleMapping. |
-| categoryAxis  | [CategoryAxisOptions](#categoryaxisoptions) | Used to create a category-based axis for the chart.   |
-| valueAxis     | [ValueAxisOptions](#valueaxisoptions)       | Used to create a value axis for the chart.            |
-
-### AxisOptions
-
-These are only the common options supported by all axes. Please see specific axis documentation for all the available options for that axis.
-
-| Name        | Type                                               | Default | Description                                                                                                                                        |
-| ----------- | -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title       | `string`                                           |         | Title of value axis.                                                                                                                               |
-| type        | `category` \| `time`                               |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart. |
-| position    | `left` \| `right` \| `top` \| `bottom` \| `center` |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.             |
-| display     | `boolean`                                          | `true`  | Controls the axis global visibility (visible when true, hidden when false).                                                                        |
-| gridDisplay | `boolean`                                          | `true`  | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                |
-| stacked     | `boolean`                                          | `false` | Should the data be stacked.                                                                                                                        |
-
-### SeriesOptions
-
-The options for the series.
-
-| Name         | Type                          | Default | Description                                                       |
-| ------------ | ----------------------------- | ------- | ----------------------------------------------------------------- |
-| styleMapping | [styleMapping](#stylemapping) |         | The style mapping is an object where keys are string identifiers. |
-
-#### styleMapping
-
-| Name      | Type                      | Default | Description                                                                       |
-| --------- | ------------------------- | ------- | --------------------------------------------------------------------------------- |
-| key       | `string`                  |         | Series name.                                                                      |
-| type      | `bar` \| `line` \| `area` |         | The chart type of the series, if not set, it will be the same as the global type. |
-| lineStyle | `solid` \| `dashed`       | `solid` | The line style of the series                                                      |
-
-### CategoryAxisOptions
-
-CategoryAxisOptions extends [AxisOptions](#axisoptions)
-
-| Name          | Type                                                                                                 | Default | Description                                                                                                                                                  |
-| ------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| enableColor   | `boolean`                                                                                            | `false` |                                                                                                                                                              |
-| dataKey       | `string`                                                                                             |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
-| timeUnit      | `millisecond` \| `second` \| `minute` \| `hour` \| `day` \| `week` \| `month` \| `quarter` \| `year` |         | Specifies the time unit on the category axis.                                                                                                                |
-| labelFormat   | `string`                                                                                             |         | Specifies the date format of labels on the category axis. See chartjs-adapter-moment                                                                         |
-| tooltipFormat | `string`                                                                                             |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
-
-### ValueAxisOptions
-
-ValueAxisOptions extends [AxisOptions](#axisoptions)
+See [Bar Chart](./bar#options)

--- a/website/docs/tutorials/charts/line.mdx
+++ b/website/docs/tutorials/charts/line.mdx
@@ -6,125 +6,198 @@ sidebar_position: 106
 
 Line chart is a way of plotting data points on a line. Often, it is used to show trend data, or the comparison of two data sets.
 
-```jsx live
-function showComponent() {
-  const data = [
+```jsx live noInline
+const data = [
+  {
+    dateTime: '2022-12-01',
+    'New Mexico': 8757,
+    Florida: 5588,
+    Nevada: 7370,
+    Wyoming: 8478,
+    Arkansas: 2174,
+  },
+  {
+    dateTime: '2023-01-01',
+    'New Mexico': 2602,
+    Florida: 8134,
+    Nevada: 198,
+    Wyoming: 1204,
+    Arkansas: 894,
+  },
+  {
+    dateTime: '2023-02-01',
+    'New Mexico': 4191,
+    Florida: 3375,
+    Nevada: 3473,
+    Wyoming: 6359,
+    Arkansas: 7669,
+  },
+  {
+    dateTime: '2023-03-01',
+    'New Mexico': 7684,
+    Florida: 8590,
+    Nevada: 3483,
+    Wyoming: 792,
+    Arkansas: 9651,
+  },
+  {
+    dateTime: '2023-04-01',
+    'New Mexico': 5332,
+    Florida: 5670,
+    Nevada: 3803,
+    Wyoming: 8538,
+    Arkansas: 7468,
+  },
+  {
+    dateTime: '2023-05-01',
+    'New Mexico': 8579,
+    Florida: 627,
+    Nevada: 1531,
+    Wyoming: 6598,
+    Arkansas: 3762,
+  },
+  {
+    dateTime: '2023-06-01',
+    'New Mexico': 3409,
+    Florida: 2120,
+    Nevada: 7987,
+    Wyoming: 6407,
+    Arkansas: 6416,
+  },
+  {
+    dateTime: '2023-07-01',
+    'New Mexico': 5513,
+    Florida: 6070,
+    Nevada: 3558,
+    Wyoming: 351,
+    Arkansas: 8387,
+  },
+  {
+    dateTime: '2023-08-01',
+    'New Mexico': 1015,
+    Florida: 4560,
+    Nevada: 6241,
+    Wyoming: 6344,
+    Arkansas: 7394,
+  },
+  {
+    dateTime: '2023-09-01',
+    'New Mexico': 3060,
+    Florida: 6139,
+    Nevada: 9757,
+    Wyoming: 4808,
+    Arkansas: 1121,
+  },
+];
+const initialOptions = {
+  legend: { selectable: true },
+  categoryAxis: {
+    gridDisplay: true,
+    dataKey: 'dateTime',
+    type: 'time',
+    timeUnit: 'month',
+    labelFormat: 'MM/YYYY',
+  },
+  valueAxes: [
     {
-      dateTime: '2022-12-01',
-      'New Mexico': 8757,
-      Florida: 5588,
-      Nevada: 7370,
-      Wyoming: 8478,
-      Arkansas: 2174,
-    },
-    {
-      dateTime: '2023-01-01',
-      'New Mexico': 2602,
-      Florida: 8134,
-      Nevada: 198,
-      Wyoming: 1204,
-      Arkansas: 894,
-    },
-    {
-      dateTime: '2023-02-01',
-      'New Mexico': 4191,
-      Florida: 3375,
-      Nevada: 3473,
-      Wyoming: 6359,
-      Arkansas: 7669,
-    },
-    {
-      dateTime: '2023-03-01',
-      'New Mexico': 7684,
-      Florida: 8590,
-      Nevada: 3483,
-      Wyoming: 792,
-      Arkansas: 9651,
-    },
-    {
-      dateTime: '2023-04-01',
-      'New Mexico': 5332,
-      Florida: 5670,
-      Nevada: 3803,
-      Wyoming: 8538,
-      Arkansas: 7468,
-    },
-    {
-      dateTime: '2023-05-01',
-      'New Mexico': 8579,
-      Florida: 627,
-      Nevada: 1531,
-      Wyoming: 6598,
-      Arkansas: 3762,
-    },
-    {
-      dateTime: '2023-06-01',
-      'New Mexico': 3409,
-      Florida: 2120,
-      Nevada: 7987,
-      Wyoming: 6407,
-      Arkansas: 6416,
-    },
-    {
-      dateTime: '2023-07-01',
-      'New Mexico': 5513,
-      Florida: 6070,
-      Nevada: 3558,
-      Wyoming: 351,
-      Arkansas: 8387,
-    },
-    {
-      dateTime: '2023-08-01',
-      'New Mexico': 1015,
-      Florida: 4560,
-      Nevada: 6241,
-      Wyoming: 6344,
-      Arkansas: 7394,
-    },
-    {
-      dateTime: '2023-09-01',
-      'New Mexico': 3060,
-      Florida: 6139,
-      Nevada: 9757,
-      Wyoming: 4808,
-      Arkansas: 1121,
-    },
-  ];
-  const options = {
-    legend: { selectable: true },
-    categoryAxis: {
       gridDisplay: true,
-      dataKey: 'dateTime',
-      type: 'time',
-      timeUnit: 'month',
-      labelFormat: 'MM/YYYY',
+      position: 'left',
     },
-    valueAxes: [
-      {
-        gridDisplay: true,
-        position: 'left',
-      },
-    ],
-    seriesOptions: {
-      styleMapping: {
-        Florida: {
-          tension: 0.3,
-          order: 1,
-        },
+  ],
+  seriesOptions: {
+    styleMapping: {
+      Florida: {
+        order: 1,
       },
     },
-  };
-  return (
-    <div>
-      <mdw-chart
-        type="line"
-        style={{ height: '300px' }}
-        data={JSON.stringify(data)}
-        options={JSON.stringify(options)}
-      ></mdw-chart>
-    </div>
-  );
-}
+  },
+};
+const Example = () =>
+  getExample(initialOptions, data, ({ key, data, options, setOptions }) => {
+    const Buttons = () => (
+      <>
+        <Button onClick={() => setOptions(initialOptions)}>No Tension</Button>
+        <Button
+          onClick={() =>
+            setOptions({
+              seriesOptions: {
+                styleMapping: {
+                  'New Mexico': {
+                    tension: 0.3,
+                  },
+                  Nevada: {
+                    tension: 0.3,
+                  },
+                  Wyoming: {
+                    tension: 0.3,
+                  },
+                  Florida: {
+                    tension: 0.3,
+                  },
+                  Arkansas: {
+                    tension: 0.3,
+                  },
+                },
+              },
+            })
+          }
+        >
+          All Tension
+        </Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                seriesOptions: {
+                  styleMapping: {
+                    Florida: {
+                      tension: 0.3,
+                    },
+                  },
+                },
+              },
+              false,
+            )
+          }
+        >
+          Single Tension
+        </Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                seriesOptions: {
+                  styleMapping: {
+                    Florida: {
+                      type: 'dashed',
+                    },
+                  },
+                },
+              },
+              false,
+            )
+          }
+        >
+          Dashed Line
+        </Button>
+        {buttonsRelatedToColor(setOptions)}
+      </>
+    );
+
+    return (
+      <WithActions buttons={<Buttons />}>
+        <mdw-chart
+          key={key}
+          style={{ height: '300px' }}
+          type="line"
+          data={JSON.stringify(data)}
+          options={JSON.stringify(options)}
+        ></mdw-chart>
+      </WithActions>
+    );
+  });
+
+render(<Example />);
 ```
 
 ## Type
@@ -133,62 +206,8 @@ type = 'line'
 
 ## Data
 
-The data supports the following multiple data formats:
-
-| Mode                  | Type                               | Example                                                                                                                  |
-| --------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Two-dimensional array | unknown[][]                        | [['Year','Things'],['2004',1000],['2005',1170],['2006',660],['2007',1030]]                                               |
-| Array                 | Record<string, string \| number>[] | [{"Year":"2004","Things":1000},{"Year":"2005","Things":1170},{"Year":"2006","Things":660},{"Year":"2007","Things":1030}] |
+See [Bar Chart](./bar#data)
 
 ## Options
 
-| Name          | Type                                        | Description                                           |
-| ------------- | ------------------------------------------- | ----------------------------------------------------- |
-| seriesOptions | [SeriesOptions](#seriesoptions)             | Series related configuration, including styleMapping. |
-| categoryAxis  | [CategoryAxisOptions](#categoryaxisoptions) | Used to create a category-based axis for the chart.   |
-| valueAxis     | [ValueAxisOptions](#valueaxisoptions)       | Used to create a value axis for the chart.            |
-
-### AxisOptions
-
-These are only the common options supported by all axes. Please see specific axis documentation for all the available options for that axis.
-
-| Name        | Type                                               | Default | Description                                                                                                                                        |
-| ----------- | -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title       | `string`                                           |         | Title of value axis.                                                                                                                               |
-| type        | `category` \| `time`                               |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart. |
-| position    | `left` \| `right` \| `top` \| `bottom` \| `center` |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.             |
-| display     | `boolean`                                          | `true`  | Controls the axis global visibility (visible when true, hidden when false).                                                                        |
-| gridDisplay | `boolean`                                          | `true`  | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                |
-| stacked     | `boolean`                                          | `false` | Should the data be stacked.                                                                                                                        |
-
-### SeriesOptions
-
-The options for the series.
-
-| Name         | Type                          | Default | Description                                                       |
-| ------------ | ----------------------------- | ------- | ----------------------------------------------------------------- |
-| styleMapping | [styleMapping](#stylemapping) |         | The style mapping is an object where keys are string identifiers. |
-
-#### styleMapping
-
-| Name      | Type                      | Default | Description                                                                       |
-| --------- | ------------------------- | ------- | --------------------------------------------------------------------------------- |
-| key       | `string`                  |         | Series name.                                                                      |
-| type      | `bar` \| `line` \| `area` |         | The chart type of the series, if not set, it will be the same as the global type. |
-| lineStyle | `solid` \| `dashed`       | `solid` | The line style of the series                                                      |
-
-### CategoryAxisOptions
-
-CategoryAxisOptions extends [AxisOptions](#axisoptions)
-
-| Name          | Type                                                                                                 | Default | Description                                                                                                                                                  |
-| ------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| enableColor   | `boolean`                                                                                            | `false` |                                                                                                                                                              |
-| dataKey       | `string`                                                                                             |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
-| timeUnit      | `millisecond` \| `second` \| `minute` \| `hour` \| `day` \| `week` \| `month` \| `quarter` \| `year` |         | Specifies the time unit on the category axis.                                                                                                                |
-| labelFormat   | `string`                                                                                             |         | Specifies the date format of labels on the category axis. See chartjs-adapter-moment                                                                         |
-| tooltipFormat | `string`                                                                                             |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
-
-### ValueAxisOptions
-
-ValueAxisOptions extends [AxisOptions](#axisoptions)
+See [Bar Chart](./bar#options)

--- a/website/docs/tutorials/charts/mixed.mdx
+++ b/website/docs/tutorials/charts/mixed.mdx
@@ -81,3 +81,11 @@ function showComponent() {
   );
 }
 ```
+
+## Data
+
+See [Bar Chart](./bar#data)
+
+## Options
+
+See [Bar Chart](./bar#options)

--- a/website/docs/tutorials/charts/range.mdx
+++ b/website/docs/tutorials/charts/range.mdx
@@ -6,50 +6,77 @@ sidebar_position: 109
 
 Range chart support a fill area on the dataset object which can be used to create space between two datasets.
 
-```jsx live
-function showComponent() {
-  const data = [
-    ['Year', 'Unfilled', 'Filled'],
-    ['2004', 1000, 400],
-    ['2005', 1170, 460],
-    ['2006', 660, 1120],
-    ['2008', 630, 540],
-    ['2009', 1030, 740],
-    ['2010', 930, 640],
-    ['2011', 530, 340],
-    ['2012', 1030, 240],
-  ];
-  const options = {
-    valueAxes: [
-      {
-        position: 'left',
-        title: 'Left Title',
-      },
-      {
-        gridDisplay: false,
-        position: 'right',
-        title: 'Right Title',
-      },
-    ],
-    seriesOptions: {
-      styleMapping: {
-        Filled: {
-          valueAxisIndex: 1,
-        },
-      },
+```jsx live noInline
+const data = [
+  ['Year', 'Unfilled', 'Filled'],
+  ['2004', 1000, 400],
+  ['2005', 1170, 460],
+  ['2006', 660, 1120],
+  ['2008', 630, 540],
+  ['2009', 1030, 740],
+  ['2010', 930, 640],
+  ['2011', 530, 340],
+  ['2012', 1030, 240],
+];
+const initialOptions = {
+  seriesOptions: {},
+  valueAxes: [
+    {
+      position: 'left',
+      title: 'Left Title',
     },
-  };
-  return (
-    <div>
-      <mdw-chart
-        type="range"
-        style={{ height: '300px' }}
-        data={JSON.stringify(data)}
-        options={JSON.stringify(options)}
-      ></mdw-chart>
-    </div>
-  );
-}
+  ],
+};
+const Example = () =>
+  getExample(initialOptions, data, ({ key, data, options, setOptions }) => {
+    const Buttons = () => (
+      <>
+        <Button onClick={() => setOptions(initialOptions)}>Single Axis</Button>
+        <Button
+          onClick={() =>
+            setOptions(
+              {
+                seriesOptions: {
+                  styleMapping: {
+                    Filled: { valueAxisIndex: 1 },
+                  },
+                },
+                valueAxes: [
+                  {
+                    position: 'left',
+                    title: 'Left Title',
+                  },
+                  {
+                    gridDisplay: false,
+                    position: 'right',
+                    title: 'Right Title',
+                  },
+                ],
+              },
+              false,
+            )
+          }
+        >
+          Multi Axis
+        </Button>
+        {buttonsRelatedToColor(setOptions)}
+      </>
+    );
+
+    return (
+      <WithActions buttons={<Buttons />}>
+        <mdw-chart
+          key={key}
+          style={{ height: '300px' }}
+          type="range"
+          data={JSON.stringify(data)}
+          options={JSON.stringify(options)}
+        ></mdw-chart>
+      </WithActions>
+    );
+  });
+
+render(<Example />);
 ```
 
 ## Type
@@ -58,62 +85,8 @@ type = 'range'
 
 ## Data
 
-The data supports the following multiple data formats:
-
-| Mode                  | Type                               | Example                                                                                                                  |
-| --------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Two-dimensional array | unknown[][]                        | [['Year','Things'],['2004',1000],['2005',1170],['2006',660],['2007',1030]]                                               |
-| Array                 | Record<string, string \| number>[] | [{"Year":"2004","Things":1000},{"Year":"2005","Things":1170},{"Year":"2006","Things":660},{"Year":"2007","Things":1030}] |
+See [Bar Chart](./bar#data)
 
 ## Options
 
-| Name          | Type                                        | Description                                           |
-| ------------- | ------------------------------------------- | ----------------------------------------------------- |
-| seriesOptions | [SeriesOptions](#seriesoptions)             | Series related configuration, including styleMapping. |
-| categoryAxis  | [CategoryAxisOptions](#categoryaxisoptions) | Used to create a category-based axis for the chart.   |
-| valueAxis     | [ValueAxisOptions](#valueaxisoptions)       | Used to create a value axis for the chart.            |
-
-### AxisOptions
-
-These are only the common options supported by all axes. Please see specific axis documentation for all the available options for that axis.
-
-| Name        | Type                                               | Default | Description                                                                                                                                        |
-| ----------- | -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title       | `string`                                           |         | Title of value axis.                                                                                                                               |
-| type        | `category` \| `time`                               |         | Type of scale being employed. Custom scales can be created and registered with a string key. This allows changing the type of an axis for a chart. |
-| position    | `left` \| `right` \| `top` \| `bottom` \| `center` |         | The location of the axis on the chart. Setting the position can determine whether the chart is a horizontal chart or a vertical chart.             |
-| display     | `boolean`                                          | `true`  | Controls the axis global visibility (visible when true, hidden when false).                                                                        |
-| gridDisplay | `boolean`                                          | `true`  | Controls the grid of axis global visibility (visible when true, hidden when false).                                                                |
-| stacked     | `boolean`                                          | `false` | Should the data be stacked.                                                                                                                        |
-
-### SeriesOptions
-
-The options for the series.
-
-| Name         | Type                          | Default | Description                                                       |
-| ------------ | ----------------------------- | ------- | ----------------------------------------------------------------- |
-| styleMapping | [styleMapping](#stylemapping) |         | The style mapping is an object where keys are string identifiers. |
-
-#### styleMapping
-
-| Name      | Type                | Default | Description                                                                       |
-| --------- | ------------------- | ------- | --------------------------------------------------------------------------------- |
-| key       | `string`            |         | Series name.                                                                      |
-| type      | `line`              |         | The chart type of the series, if not set, it will be the same as the global type. |
-| lineStyle | `solid` \| `dashed` | `solid` | The line style of the series                                                      |
-
-### CategoryAxisOptions
-
-CategoryAxisOptions extends [AxisOptions](#axisoptions)
-
-| Name          | Type                                                                                                 | Default | Description                                                                                                                                                  |
-| ------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| enableColor   | `boolean`                                                                                            | `false` |                                                                                                                                                              |
-| dataKey       | `string`                                                                                             |         | Specifies the category field on the category axis. If not specified, the first field name of the first piece of data in data will be automatically obtained. |
-| timeUnit      | `millisecond` \| `second` \| `minute` \| `hour` \| `day` \| `week` \| `month` \| `quarter` \| `year` |         | Specifies the time unit on the category axis.                                                                                                                |
-| labelFormat   | `string`                                                                                             |         | Specifies the date format of labels on the category axis. See chartjs-adapter-moment                                                                         |
-| tooltipFormat | `string`                                                                                             |         | Specifies the format of the tooltip displayed for data points on the category axis.                                                                          |
-
-### ValueAxisOptions
-
-ValueAxisOptions extends [AxisOptions](#axisoptions)
+See [Bar Chart](./bar#options)


### PR DESCRIPTION
## Description

> Add shortcut buttons to examples 
> Improve wiki


## Screenshots

<img width="1071" alt="image" src="https://github.com/momentum-design/momentum-widgets/assets/20723412/f96bdd96-7c97-45a8-b179-f0e124986871">


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and example
