### PR TITLE
fix(pie): reset pie series border width to 1

### DIFF
--- a/src/lib/pie/pie.ts
+++ b/src/lib/pie/pie.ts
@@ -222,7 +222,7 @@ export class PieChart<TData extends PieData, TOptions extends PieChartOptions> e
     dataset.label = series.name;
     dataset.type = ChartType.Pie;
     dataset.backgroundColor = chartBG;
-    dataset.borderWidth = 0;
+    dataset.borderWidth = 1;
     return dataset;
   }
 


### PR DESCRIPTION
## Description

> Reset the pie series border width to 1.


## Screenshots
![image](https://github.com/momentum-design/momentum-widgets/assets/159236641/417003a8-34d6-4825-b0bd-86ced61ae006)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and example
